### PR TITLE
Add keyboard focus support for elements

### DIFF
--- a/typography-cheatsheet.css
+++ b/typography-cheatsheet.css
@@ -29,9 +29,12 @@ svg {
     margin: 0 auto;
     max-width: 100%;
 }
-#elements path:hover, #elements polygon:hover {
-    fill:#ccc;
+#elements path, #elements polygon {
     transition: 300ms;
+}
+#elements path:hover, #elements polygon:hover,
+#elements path:focus, #elements polygon:focus {
+    fill:#ccc;
 }
 footer {
     text-align: right;

--- a/typography-cheatsheet.js
+++ b/typography-cheatsheet.js
@@ -7,10 +7,15 @@ const setbanner = (msg, x, y) => {
 	banner.style.top = y + "px";
 	banner.style.left = x + "px";
 }
+const clearbanner = () => {
+	banner.querySelector('span').innerText = '';
+}
 const seteventhandlers = () => {
 	let elements = document.querySelector('#elements');
+	let shapes = [...elements.querySelectorAll('[id^="e"]')];
 	elements.addEventListener('click', handleselect);
-	[...elements.querySelectorAll('[id^="e"]')].forEach(element => element.addEventListener('focus', handleselect));
+	shapes.forEach(element => element.addEventListener('focus', handleselect));
+	shapes.forEach(element => element.addEventListener('blur', clearbanner));
 }
 const setfocusableelements = () => {
 	const elements = document.querySelectorAll('#elements [id^="e"]');

--- a/typography-cheatsheet.js
+++ b/typography-cheatsheet.js
@@ -10,14 +10,21 @@ const setbanner = (msg, x, y) => {
 const seteventhandlers = () => {
 	let elements = document.querySelector('#elements');
 	elements.addEventListener('click', handleselect);
+	[...elements.querySelectorAll('[id^="e"]')].forEach(element => element.addEventListener('focus', handleselect));
+}
+const setfocusableelements = () => {
+	const elements = document.querySelectorAll('#elements [id^="e"]');
+	elements.forEach(element => element.setAttribute('tabindex', 0));
 }
 const handleselect = (ev) => {
+	const rect = ev.target.getBoundingClientRect();
 	if (['path','polygon','g'].indexOf(ev.target.nodeName.toLowerCase()) !== -1){
-		setbanner((information[ev.target.id]), ev.pageX, ev.pageY);
+		setbanner((information[ev.target.id]), rect.left + rect.width, rect.top + rect.height);
 		ev.preventDefault();
 	}
 };
 const init = () => {
+	setfocusableelements();
 	seteventhandlers();
 }
 init();

--- a/typography-cheatsheet.js
+++ b/typography-cheatsheet.js
@@ -17,9 +17,9 @@ const setfocusableelements = () => {
 	elements.forEach(element => element.setAttribute('tabindex', 0));
 }
 const handleselect = (ev) => {
-	const rect = ev.target.getBoundingClientRect();
+	const { width, height, top, left } = ev.target.getBoundingClientRect();
 	if (['path','polygon','g'].indexOf(ev.target.nodeName.toLowerCase()) !== -1){
-		setbanner((information[ev.target.id]), rect.left + rect.width, rect.top + rect.height);
+		setbanner((information[ev.target.id]), left + width, top + height);
 		ev.preventDefault();
 	}
 };


### PR DESCRIPTION
By programatically adding `tabindex` attributes to SVG elements and binding `focus` handlers, we can offer keyboard support to quickly cycle through elements.

Includes a minor adjustment to banner positioning, to avoid obscuring highlighted element (getting `rect` instead of `ev.pageX/Y` ensures banner can be positioned dynamically on both `click` and `focus` handlers).

Some ES6 features could be ES5-fied for broader browser support. Open to suggestions 👌  